### PR TITLE
soum 230201

### DIFF
--- a/config/testconfig4.conf
+++ b/config/testconfig4.conf
@@ -36,7 +36,7 @@ server{
 	cgi_pass .bla /cgi-bin/cgi_tester;
 
 	location / {
-		limit_except GET;
+		limit_except POST PUT HEAD;
 	}
 
 	location /put_test/ {

--- a/src/VirtualServer.hpp
+++ b/src/VirtualServer.hpp
@@ -42,7 +42,7 @@ private:
 // friends
 	friend class			ConfigParser;
 	friend class			ServerParser;
-	friend void				RequestHandler::createResponseHeader();
+	friend void				RequestHandler::checkRequestMessage();
 	friend std::ostream&	operator<<(std::ostream& os, const VirtualServer& server);
 };
 

--- a/src/http/RequestHandler.hpp
+++ b/src/http/RequestHandler.hpp
@@ -63,14 +63,14 @@ public:
 	int		sendResponse();
 	void	resetStates();
 
-	void	createResponseHeader();
 	std::string	findContentType(std::string& content);
+	void	checkRequestMessage();
 private:
 	VirtualServer*	resolveVirtualServer(const std::string& host);
 	int				resolveResourceLocation(std::map<std::string, Location>& locationTable);
 
+	void	createResponseHeader();
 	void	checkResourceStatus();
-	void	checkRequestMessage();
 	void	checkStatusLine();
 	void	checkHeaderFields();
 	void	checkAllowedMethod(uint16_t allowed);
@@ -79,6 +79,8 @@ private:
 	void	bufferResponseHeaderFields();
 
 	void	makeErrorResponse(const std::string& errorMessage);
+
+	std::string methodToString(uint16_t allowed);
 
 // member variables
 	const Socket<Tcp>*	m_socket;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,6 @@
 #include "Webserv.hpp"
 #include "Logger.hpp"
 #include "ServerManager.hpp"
-#//include "parser/ConfigParser.hpp"
-//#include "exception/ConfigParserException.hpp"
 #include "util/Util.hpp"
 
 using namespace	std;


### PR DESCRIPTION
fix : RequestHandler::checkRequestMessage()

feature : 405 error code일때 allow response header 추가

- RequestHandler::checkRequestMessage() - 해당함수에서 request header까지 읽은 message에서 모든 에러 발생 확인